### PR TITLE
chore(deps): upgrade all dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,11 +4,11 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-anyhow = "1.0.91"
+anyhow = "1.0.102"
 bollard = "0.21.0"
-clap = { version = "4.5.60", features = ["derive", "env", "string"] }
+clap = { version = "4.6.1", features = ["derive", "env", "string"] }
 dirs = "6.0.0"
-flate2 = "1.0.34"
+flate2 = "1.1.9"
 futures-util = "0.3.32"
 glob = "0.3.1"
 oxc_allocator = "0.131.0"
@@ -20,10 +20,10 @@ oxc_parser = "0.131.0"
 oxc_resolver = "11.19.1"
 oxc_span = "0.131.0"
 remove_empty_subdirs = "0.1.1"
-serde_json = "1.0.132"
+serde_json = "1.0.149"
 strum = { version = "0.28.0", features = ["derive"] }
 tar = "0.4.45"
-tokio = { version = "1.43.1", features = ["full"] }
+tokio = { version = "1.52.3", features = ["full"] }
 
 [dev-dependencies]
 assert_fs = "1.1.3"

--- a/src/minifier.rs
+++ b/src/minifier.rs
@@ -33,7 +33,7 @@ fn retrieve_files_by_extension(configurations: &Cli, extension: &str) -> Vec<Pat
 /// This function builds a compiler for minifying JavaScript files. The compiler
 /// is configured to use the latest ECMAScript version and to minify the code.
 fn build_minifier() -> impl Fn(&PathBuf) -> Result<String, Error> {
-    return move |path: &PathBuf| -> Result<String, Error> {
+    move |path: &PathBuf| -> Result<String, Error> {
         let allocator = Allocator::default();
         let source_text = std::fs::read_to_string(path)?;
         let source_type = SourceType::from_path(path)?;
@@ -52,7 +52,7 @@ fn build_minifier() -> impl Fn(&PathBuf) -> Result<String, Error> {
             .with_scoping(ret.scoping)
             .build(&program)
             .code)
-    };
+    }
 }
 
 /// Minify JavaScript files

--- a/src/module_graph.rs
+++ b/src/module_graph.rs
@@ -97,7 +97,7 @@ impl<'a> Visitor {
     }
 
     fn is_file_module(module: &str) -> bool {
-        Path::new(&module).extension().map_or(false, |ext| {
+        Path::new(&module).extension().is_some_and(|ext| {
             ext.eq_ignore_ascii_case("json") || ext.eq_ignore_ascii_case("node")
         })
     }


### PR DESCRIPTION
## Summary

- Upgrade `anyhow` 1.0.91 → 1.0.102
- Upgrade `clap` 4.5.60 → 4.6.1
- Upgrade `tokio` 1.43.1 → 1.52.3
- Upgrade `flate2` 1.0.34 → 1.1.9
- Upgrade `serde_json` 1.0.132 → 1.0.149

## Fixes

- Fixed clippy warning: removed needless `return` in `src/minifier.rs`
- Fixed clippy warning: simplified `map_or` to `is_some_and` in `src/module_graph.rs`

## Test Plan

- [x] `cargo check` passes
- [x] `cargo clippy --lib` passes (no warnings)
- [x] `cargo test --lib` passes (16 tests)