### PR TITLE
ci: limit docker_image job to main branch only

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -63,6 +63,7 @@ jobs:
   docker_image:
     runs-on: ubuntu-latest
     needs: build
+    if: github.ref == 'refs/heads/main'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Limit `docker_image` job to run only on `main` branch using `if: github.ref == 'refs/heads/main'`

## Test plan
- [ ] Verify workflow runs on PRs against main (docker_image should be skipped)
- [ ] Verify workflow runs on push to main (docker_image should run)